### PR TITLE
Bump to 0.7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: objective-c
 before_script:
 - brew update
+- brew upgrade brew-cask
 script:
 - make
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 before_script:
 - brew update
-- brew upgrade brew-cask
+- umask 027 # see https://github.com/Homebrew/homebrew/issues/46419
 script:
 - make
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ FORMULA = gitlab-ci-multi-runner
 test:
 	# Setup
 	cp $(FORMULA).rb $(shell brew --repository)/Library/Formula
-	chmod 644 $(shell brew --repository)/Library/Formula/$(FORMULA).rb
+	chmod 640 $(shell brew --repository)/Library/Formula/$(FORMULA).rb
 
 	# Run tests
 	brew reinstall $(FORMULA)

--- a/gitlab-ci-multi-runner.rb
+++ b/gitlab-ci-multi-runner.rb
@@ -2,8 +2,8 @@ class GitlabCiMultiRunner < Formula
   desc "The official GitLab CI runner written in Go"
   homepage "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner"
   url "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner.git",
-    :tag => "v0.6.2",
-    :revision => "3227f0aa5be1d64d2ec694bd3758e0d43e92b36b"
+    :tag => "v0.7.2",
+    :revision => "998cf5d5ef3caf6535cc4c5f3279b08c3ee2ecc8"
 
   head "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner.git"
 


### PR DESCRIPTION
Changes:
- Bump gitlab-ci-multi-runner to v0.7.2
- Set `umask` to `027` explicitly, see https://github.com/Homebrew/homebrew/issues/46419
